### PR TITLE
Remove E-Mail Field from ResourceOwner

### DIFF
--- a/src/Provider/StravaResourceOwner.php
+++ b/src/Provider/StravaResourceOwner.php
@@ -31,16 +31,6 @@ class StravaResourceOwner implements ResourceOwnerInterface
     }
 
     /**
-     * Returns resource owner email.
-     *
-     * @return string|null
-     */
-    public function getEmail()
-    {
-        return $this->response['email'] ?: null;
-    }
-
-    /**
      * Returns resource owner first name.
      *
      * @return string|null

--- a/tests/src/Provider/StravaTest.php
+++ b/tests/src/Provider/StravaTest.php
@@ -119,7 +119,6 @@ class StravaTest extends \PHPUnit_Framework_TestCase
         $userId    = rand(1000, 9999);
         $firstName = uniqid();
         $lastName  = uniqid();
-        $email     = uniqid();
         $premium   = false;
 
         $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
@@ -130,7 +129,7 @@ class StravaTest extends \PHPUnit_Framework_TestCase
         $postResponse->shouldReceive('getStatusCode')->andReturn(200);
         $userResponse = m::mock('Psr\Http\Message\ResponseInterface');
         $userResponse->shouldReceive('getBody')->andReturn(
-            '{"id": ' . $userId . ', "firstname": "' . $firstName . '", "lastname": "' . $lastName . '", "email": "' . $email . '", "premium": "' . $premium . '"}'
+            '{"id": ' . $userId . ', "firstname": "' . $firstName . '", "lastname": "' . $lastName . '", "premium": "' . $premium . '"}'
         );
         $userResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
         $userResponse->shouldReceive('getStatusCode')->andReturn(200);
@@ -149,8 +148,6 @@ class StravaTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($lastName, $user->toArray()['lastname']);
         $this->assertEquals($premium, $user->getPremium());
         $this->assertEquals($premium, $user->toArray()['premium']);
-        $this->assertEquals($email, $user->getEmail());
-        $this->assertEquals($email, $user->toArray()['email']);
     }
 
     /**


### PR DESCRIPTION
Removed E-Mail field from ResourceOwner, as it is not available anymore.
See https://developers.strava.com/docs/changelog/#january-17-2019
