### PR TITLE
Update default scope

### DIFF
--- a/src/Provider/Strava.php
+++ b/src/Provider/Strava.php
@@ -93,7 +93,7 @@ class Strava extends AbstractProvider
      */
     protected function getDefaultScopes()
     {
-        return ['public'];
+        return ['read'];
     }
 
     /**


### PR DESCRIPTION
Updating the default scope to match the new scopes.
See https://developers.strava.com/docs/oauth-updates/#scopes-update

`read` is the minimal requirement to get the info about the resource owner.